### PR TITLE
Fixes the deletion of the target directory after installation

### DIFF
--- a/config/plugins/bower.coffee
+++ b/config/plugins/bower.coffee
@@ -13,4 +13,4 @@ module.exports = (lineman) ->
       install:
         options:
           targetDir: "vendor/bower"
-          cleanBowerDir: true
+          cleanTargetDir: true


### PR DESCRIPTION
Looking into the documentation of the grunt-bower-task we read:

options.cleanTargetDir: Will clean target dir BEFORE running install.
options.cleanBowerDir: Will remove bower's dir AFTER copying all needed files into target dir.

Therefore, what we really want is cleanTargetDir instead of
cleanBowerDir
