### PR TITLE
Upgrade grunt-bower-task to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "node script/postinstall.js"
   },
   "dependencies": {
-    "grunt-bower-task": "~0.3.4",
+    "grunt-bower-task": "~0.4.0",
     "coffee-script": "~1.6.3",
     "grunt": "~0.4.2"
   },


### PR DESCRIPTION
Before:

``` bash
$ lineman grunt bower:install
Running "bower:install" (bower) task
Fatal error: Arguments to path.join must be strings
```

After:

``` bash
$ lineman grunt bower:install 
Running "bower:install" (bower) task
>> Installed bower packages

Done, without errors.
```
